### PR TITLE
Inflate symbolic links to avoid failing to fetch node-modules from cordova-blackberry

### DIFF
--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -58,7 +58,8 @@ _self = {
         if (!fs.existsSync(cliBBLib)) {
             wrench.mkdirSyncRecursive(cliBBLib, 0775);
             wrench.copyDirSyncRecursive(conf.CORDOVA_BB_DIR, cliBBLib, {
-                forceDelete: true
+                forceDelete: true,
+                inflateSymlinks: true
             });
 
             //Re-Adding execution permissions


### PR DESCRIPTION
Fixed `webworks create` error which failed to fetch node-modules from cordova-blackberry because of symbolic links in node-modules/.bin
