### PR TITLE
Running 'webworks create projectName' in a current project fails

### DIFF
--- a/lib/create.js
+++ b/lib/create.js
@@ -84,6 +84,7 @@ module.exports = function create (dir, id, name, template, callback) {
             function (err) {
                 if (!err && fs.existsSync(projectPath)) {
                     process.chdir(projectPath);
+                    process.env.PWD = projectPath;
                     platform("add", ["blackberry10"]);
                 }
                 if (callback) callback();


### PR DESCRIPTION
CB-5687 altered util.isCordova() to favor PWD over cwd ...
