### PR TITLE
Improve webworks help consistency

### DIFF
--- a/res/help/default.txt
+++ b/res/help/default.txt
@@ -1,12 +1,14 @@
 usage: webworks [--verbose] command [options]
 
 These commands may be used globally:
+
    create               create a new project
    create-headless      create a new project which includes a native headless component
    target               manage devices and simulators
    help                 view usage for all commands
 
 These commands may be used from within a project directory:
+
    build                package app into a BAR file
    run                  build and deploy to a device
    emulate              build and deploy to a simulator

--- a/res/help/plugin.txt
+++ b/res/help/plugin.txt
@@ -8,16 +8,20 @@ commands:
    add <id | path | uri>
       Add a plugin by id or path
 
-   rm <id>
+   remove <id>
       Remove a plugin by id
 
-   ls
+   list
       List all of the plugins added to the project
 
 options:
-    id                              unique identifier of the plugin
-    path                            path to the plugin on the filesystem
-    uri                             remote location of the plugin
+   id                              unique identifier of the plugin
+   path                            path to the plugin on the filesystem
+   uri                             remote location of the plugin
+
+aliases:
+   ls => list
+   rm => remove
 
 example:
    $ webworks plugin add com.blackberry.bbm.platform

--- a/res/help/target.txt
+++ b/res/help/target.txt
@@ -15,11 +15,11 @@ commands:
       List all of the configured targets
 
 options:
-    name                            unique identifier for the target
-    host                            IP address or hostname of the target
-    -t, --type <device | simulator> type of target, default is device
-    -p, --password <password>       target password
-    --pin <devicepin>               target PIN
+   name                            unique identifier for the target
+   host                            IP address or hostname of the target
+   -t, --type <device | simulator> type of target, default is device
+   -p, --password <password>       target password
+   --pin <devicepin>               target PIN
 
 example:
    $ webworks target add z10-wifi 192.168.2.2


### PR DESCRIPTION
The change to default.txt is to match plugin.txt

The changes for options: is to have 3 spaces before items in options: -- which matches the rest of the help entries.

aliases addresses the concern about not covering both short and long commands.
