### PR TITLE
webworks: set cordovaLib.binname

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -14,6 +14,7 @@ var path                    = require('path'),
 
 try {
     cordovaLib              = require(path.join(conf.NODE_MODULES_DIR, 'cordova', 'node_modules', 'cordova-lib'));
+    cordovaLib.binname      = 'webworks';
     cordova                 = cordovaLib.cordova;
     cli_platforms           = cordovaLib.cordova_platforms;
     cordovaCLI              = require(path.join(conf.NODE_MODULES_DIR, 'cordova', 'src', 'cli'));


### PR DESCRIPTION
This lets us get happy errors like:
    No plugins added. Use `webworks plugin add <plugin>`.

instead of:
    No plugins added. Use `cordova plugin add <plugin>`.
