### PR TITLE
Removed "no-uninstall" option from usage description

### DIFF
--- a/res/help/emulate.txt
+++ b/res/help/emulate.txt
@@ -1,5 +1,5 @@
 usage: webworks [--verbose] emulate [--devicepass <password>] [--target <name>]
-                [--no-launch] [--no-uninstall] [--no-build]
+                [--no-launch] [--no-build]
 
 description:
    Build the app and deploy it to a BlackBerry 10 Simulator.
@@ -7,7 +7,6 @@ description:
 options:
    --devicepass <password>          simulator password
    --target <name>                  specifies the pre-configured target simulator
-   --no-uninstall                   skip uninstall step
    --no-launch                      skip launch step
    --no-build                       skip build step; previously built BAR file will be used
 


### PR DESCRIPTION
webworks-cli dosen't support `no-uninstall` option any more, however `webworks emulate --help` still lists `no-uninstall` as an option.
